### PR TITLE
fix double value calculation problem

### DIFF
--- a/Ratios/Ratios/View Models/CalculatorViewModel.swift
+++ b/Ratios/Ratios/View Models/CalculatorViewModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-typealias Grams = Double
+typealias Grams = Decimal
 
 class CalculatorViewModel {
     static func calculateGramsOfWaterTimes(waterRatio: Grams, coffee: Grams) -> Grams {

--- a/Ratios/Ratios/Views/WaterDisplay.swift
+++ b/Ratios/Ratios/Views/WaterDisplay.swift
@@ -20,10 +20,10 @@ struct WaterDisplay: View {
                 .font(.system(size: 24))
 
             Text(
-                String(
+                String(describing:
                     CalculatorViewModel.calculateGramsOfWaterTimes(
-                        waterRatio: Grams(waterRatio) ?? 0.0,
-                        coffee: Grams(coffee) ?? 0.0
+                        waterRatio: Grams(string: waterRatio) ?? 0.0,
+                        coffee: Grams(string: coffee) ?? 0.0
                     )
                 )
             )


### PR DESCRIPTION
the grams of water might be wrong sometimes since it uses double value for calculation
replace double with decimal and fix this problem

![Simulator Screen Shot - iPhone 14 Pro - 2022-12-07 at 12 00 28](https://user-images.githubusercontent.com/30222789/206096033-4280c0b6-bbab-424b-87a0-26f8860567e7.png)
